### PR TITLE
Small fixes

### DIFF
--- a/include/directshow_camera/uvc_camera.h
+++ b/include/directshow_camera/uvc_camera.h
@@ -39,8 +39,9 @@ namespace DirectShowCamera
 
     /**********************Public********************************/
     public:
-
+#ifdef HAS_OPENCV
         typedef std::function<void(cv::Mat image)> ExposureFusionAsyncResult;
+#endif
 
         // Constructor
         UVCCamera();

--- a/src/uvc_camera.cpp
+++ b/src/uvc_camera.cpp
@@ -199,8 +199,7 @@ namespace DirectShowCamera
         else
         {
             // Release device input filter
-            videoInputFilter->Release();
-            delete videoInputFilter;
+            DirectShowCameraUtils::SafeRelease(&videoInputFilter);
 
             copyError(result);
         }


### PR DESCRIPTION
Two small fixes:

- uvc_camera.h no longer references opencv types when HAS_OPENCV is not set
- IBaseFilter was erroneously deleted