### PR TITLE
Support devices that do not have a devpath set (e.g. OBS Virtual Camera)

### DIFF
--- a/src/ds_camera.cpp
+++ b/src/ds_camera.cpp
@@ -1073,11 +1073,11 @@ namespace DirectShowCamera
                 hr = propertyBag->Read(L"DevicePath", &var, 0);
                 if (SUCCEEDED(hr))
                 {
-                    std::string dev_path = DirectShowCameraUtils::bstrToString(var.bstrVal);
+                    std::string currentDevicePath = DirectShowCameraUtils::bstrToString(var.bstrVal);
                     VariantClear(&var);
 
                     // Found, obtain the video input filter
-                    if (dev_path == devicePath)
+                    if (currentDevicePath == devicePath)
                     {
                         // Get device name
                         moniker->BindToObject(NULL, NULL, IID_IBaseFilter, (void**)videoInputFilter);


### PR DESCRIPTION
This allows devices without a devpath set to appear in the list returned by `getCameras`, and changes the `getCamera` function so that it finds these devices by name if not device path match was found.
I also changed the `getCamera` functions to only return true if a camera was found, previously it always returned true if the enumeration itself succeeded (which meant that the `videoInputFilter` could be a nullptr, even if the function returned true).

The main motivation was to access images from the OBS Virtual Camera. This also requires `syncSourceAsNull` to be set to true, and for the open call to specify a resolution and the rgb parameter set to true. Otherwise the `OpenCVMatConverter` cannot convert the video type.