### PR TITLE
Use video format configured in sample grabber

### DIFF
--- a/include/directshow_camera/abstract_ds_camera.h
+++ b/include/directshow_camera/abstract_ds_camera.h
@@ -45,6 +45,7 @@ namespace DirectShowCamera
         virtual  std::vector<DirectShowVideoFormat> getVideoFormatList() = 0;
         virtual int getCurrentVideoFormatIndex() = 0;
         virtual DirectShowVideoFormat getCurrentVideoFormat() = 0;
+        virtual DirectShowVideoFormat getCurrentGrabberFormat() = 0;
 
         virtual bool setVideoFormat(DirectShowVideoFormat* videoFormat) = 0;
         virtual bool setVideoFormat(int videoFormatIndex) = 0;

--- a/include/directshow_camera/ds_camera.h
+++ b/include/directshow_camera/ds_camera.h
@@ -44,6 +44,7 @@ namespace DirectShowCamera
         ISampleGrabber* m_sampleGrabber = NULL;
         SampleGrabberCallback* m_sampleGrabberCallback = new SampleGrabberCallback();
         GUID m_grabberMediaSubType = MEDIASUBTYPE_None;
+        DirectShowVideoFormat m_sampleGrabberVideoFormat;
 
         IMediaEventEx* m_mediaEvent = NULL;
         IMediaControl* m_mediaControl = NULL;
@@ -91,6 +92,7 @@ namespace DirectShowCamera
         std::vector<DirectShowVideoFormat> getVideoFormatList();
         int getCurrentVideoFormatIndex();
         DirectShowVideoFormat getCurrentVideoFormat();
+        DirectShowVideoFormat getCurrentGrabberFormat();
 
         bool setVideoFormat(DirectShowVideoFormat* videoFormat);
         bool setVideoFormat(int videoFormatIndex);

--- a/include/directshow_camera/ds_camera_stub.h
+++ b/include/directshow_camera/ds_camera_stub.h
@@ -80,6 +80,7 @@ namespace DirectShowCamera
         std::vector<DirectShowVideoFormat> getVideoFormatList();
         int getCurrentVideoFormatIndex();
         DirectShowVideoFormat getCurrentVideoFormat();
+        DirectShowVideoFormat getCurrentGrabberFormat();
 
         bool setVideoFormat(DirectShowVideoFormat* videoFormat);
         bool setVideoFormat(int videoFormatIndex);

--- a/src/ds_camera.cpp
+++ b/src/ds_camera.cpp
@@ -271,6 +271,15 @@ namespace DirectShowCamera
                 result = DirectShowCameraUtils::checkICGB2RenderStreamResult(hr, &m_errorString, "Error on connecting filter (Video Input Filter - Grabber Filter - Null Renderer Filter)");
             }
 
+            // get video format of connected grabber filter
+            AM_MEDIA_TYPE grabberMediaType;
+            ZeroMemory(&grabberMediaType, sizeof(grabberMediaType));
+            hr = m_sampleGrabber->GetConnectedMediaType(&grabberMediaType);
+            if (SUCCEEDED(hr))
+            {
+                m_sampleGrabberVideoFormat.constructor(&grabberMediaType, false);
+            }
+
             // Try setting the sync source to null - and make it run as fast as possible
             bool syncSourceAsNull = false;
             if (result && syncSourceAsNull)
@@ -666,6 +675,13 @@ namespace DirectShowCamera
             {
                 m_grabberMediaSubType = mediaSubType;
 
+                // get video format of grabber filter - this can fail if the graph is not yet connected
+                hr = m_sampleGrabber->GetConnectedMediaType(&grabberMediaType);
+                if (SUCCEEDED(hr))
+                {
+                    m_sampleGrabberVideoFormat.constructor(&grabberMediaType, false);
+                }
+
                 // Set buffer size
                 m_sampleGrabberCallback->setBufferSize(frameTotalSize);
             }
@@ -797,6 +813,15 @@ namespace DirectShowCamera
             return DirectShowVideoFormat();
         }
         
+    }
+
+    /**
+    * @brief Get current grabber format
+    * @return
+    */
+    DirectShowVideoFormat DirectShowCamera::getCurrentGrabberFormat()
+    {
+        return m_sampleGrabberVideoFormat;
     }
 
     /**

--- a/src/ds_camera.cpp
+++ b/src/ds_camera.cpp
@@ -37,6 +37,9 @@ namespace DirectShowCamera
             m_videoFormats = NULL;
             m_currentVideoFormatIndex = -1;
 
+            // assigning a newly created DirectShowVideoFormat will reset m_isEmpty
+            m_sampleGrabberVideoFormat = DirectShowVideoFormat();
+
             // Release stream config
             DirectShowCameraUtils::SafeRelease(&m_streamConfig);
 

--- a/src/ds_camera_stub.cpp
+++ b/src/ds_camera_stub.cpp
@@ -400,6 +400,15 @@ namespace DirectShowCamera
     }
 
     /**
+     * @brief Get current grabber format
+     * @return
+    */
+    DirectShowVideoFormat DirectShowCameraStub::getCurrentGrabberFormat()
+    {
+        return getCurrentVideoFormat();
+    }
+
+    /**
      * @brief Get current video format list of this opened camera.
      * @return
     */

--- a/src/uvc_camera.cpp
+++ b/src/uvc_camera.cpp
@@ -2525,7 +2525,7 @@ namespace DirectShowCamera
     */
     DirectShowVideoFormat UVCCamera::getDirectShowVideoFormat()
     {
-        return m_directShowCamera->getCurrentVideoFormat();
+        return m_directShowCamera->getCurrentGrabberFormat();
     }
 
 #pragma endregion DirectShow Video Format


### PR DESCRIPTION
The `getFrameSize` / `getNumOfBytePerPixel` / etc. function in UVCCamera return values from the directShowVideoFormat that is used in the graph output, but this can be different from the format returned by the sample grabber. This saves the sample grabber format, and uses it for those functions.