### PR TITLE
Properly delete grabber object, camera object and video formats

### DIFF
--- a/include/directshow_camera/abstract_ds_camera.h
+++ b/include/directshow_camera/abstract_ds_camera.h
@@ -22,6 +22,7 @@ namespace DirectShowCamera
     class AbstractDirectShowCamera
     {
     public:
+        virtual ~AbstractDirectShowCamera() { }
 
         virtual void release() = 0;
 

--- a/include/directshow_camera/ds_camera.h
+++ b/include/directshow_camera/ds_camera.h
@@ -42,7 +42,7 @@ namespace DirectShowCamera
 
         // Callback
         ISampleGrabber* m_sampleGrabber = NULL;
-        SampleGrabberCallback* m_sampleGrabberCallback = new SampleGrabberCallback();
+        SampleGrabberCallback* m_sampleGrabberCallback = NULL;
         GUID m_grabberMediaSubType = MEDIASUBTYPE_None;
         DirectShowVideoFormat m_sampleGrabberVideoFormat;
 

--- a/include/directshow_camera/ds_grabber_callback.h
+++ b/include/directshow_camera/ds_grabber_callback.h
@@ -48,6 +48,11 @@ namespace DirectShowCamera
             std::chrono::system_clock::time_point m_lastFrameTime;
             double m_fps = 0;
 
+            /**
+            * @brief Current reference count. If it reaches 0 we delete ourself
+            */
+            unsigned long m_refCount = 0;
+
         public:
 
             SampleGrabberCallback();
@@ -67,8 +72,8 @@ namespace DirectShowCamera
             double minimumFPS = 0.5;
 
             //------------------------------------------------
-            STDMETHODIMP_(ULONG) AddRef() { return 1; }
-            STDMETHODIMP_(ULONG) Release() { return 2; }
+            STDMETHODIMP_(ULONG) AddRef();
+            STDMETHODIMP_(ULONG) Release();
 
             //------------------------------------------------
             STDMETHODIMP QueryInterface(REFIID, void** ppvObject);

--- a/src/ds_camera.cpp
+++ b/src/ds_camera.cpp
@@ -125,6 +125,7 @@ namespace DirectShowCamera
         {
             m_videoInputFilter = *videoInputFilter;
 
+            m_sampleGrabberCallback = new SampleGrabberCallback();
             // Create the capture graph builder
             if (result)
             {

--- a/src/ds_grabber_callback.cpp
+++ b/src/ds_grabber_callback.cpp
@@ -126,6 +126,23 @@ namespace DirectShowCamera
         return m_lastFrameTime;
     }
 
+    ULONG SampleGrabberCallback::AddRef()
+    {
+        m_refCount++;
+        return m_refCount;
+    }
+
+    ULONG SampleGrabberCallback::Release()
+    {
+        m_refCount--;
+        if (!m_refCount)
+        {
+            delete this;
+            return 0;
+        }
+        return m_refCount;
+    }
+
     STDMETHODIMP SampleGrabberCallback::QueryInterface(REFIID, void** ppvObject) {
         *ppvObject = static_cast<ISampleGrabberCB*>(this);
         return S_OK;

--- a/src/ds_video_format.cpp
+++ b/src/ds_video_format.cpp
@@ -113,10 +113,11 @@ namespace DirectShowCamera
             for (int i=0;i< videoFormats->size();i++)
             {
                 delete videoFormats->at(i);
-                videoFormats->assign(i, NULL);
+                videoFormats->at(i) = NULL;
             }
 
             videoFormats->clear();
+            delete videoFormats;
         }
     }
 


### PR DESCRIPTION
This fixes up some memory leaks I encountered:

- `DirectShowCamera`'s destructor was never called because `AbstractDirectShowCamera` did not have a virtual destructor
- `m_sampleGrabberCallback` had fixed returns for `AddRef` and `Release`, but was set up to be freed with `SafeRelease`. This only set the pointer to NULL, but did not free anything (and would have caused problems on further `open` calls). I've implemented `AddRef` / `Release` and allocation in `open`, but the grabber could theoretically also be changed to be a permanent member.
- `DirectShowVideoFormat::release` was using `assign`, which clears the whole vector, so only the first element was deleted. The vector itself was also not deleted.