### PR TITLE
AddRef in constructor

### DIFF
--- a/src/ds_grabber_callback.cpp
+++ b/src/ds_grabber_callback.cpp
@@ -10,6 +10,7 @@ namespace DirectShowCamera
     {
         // initialize buffer
         m_pixelsBuffer = new unsigned char[m_bufferSize];
+        AddRef();
     }
 
     /**


### PR DESCRIPTION
I missed one commit, the grabber needs to start with a reference when constructed.